### PR TITLE
Provide advanced rewire rules

### DIFF
--- a/lib/map_rewire.ex
+++ b/lib/map_rewire.ex
@@ -79,12 +79,11 @@ defmodule MapRewire do
 
   def rewire(content, rules, options)
       when is_map(content) and (is_list(rules) or is_binary(rules) or is_map(rules)) do
-    debug = Keyword.get(options, :debug, @debug)
+    debug = !!Keyword.get(options, :debug, @debug)
 
-    if debug do
-      Logger.info("[MapRewire:arg1]rewire#content: #{inspect(content)}")
-      Logger.info("[MapRewire:arg2]rewire#rules: #{inspect(rules)}")
-    end
+    log(debug, "[MapRewire]rewire#content: #{inspect(content)}")
+    log(debug, "[MapRewire]rewire#rules: #{inspect(rules)}")
+    log(debug, "[MapRewire]rewire#options: #{inspect(options)}")
 
     new =
       rules
@@ -97,24 +96,13 @@ defmodule MapRewire do
   end
 
   def rewire(content, rules, _options) when is_map(content) do
-    raise ArgumentError,
-          "[MapRewire:content<~>rules] expected rules to be a list, map, or string." <>
-            " content: `#{inspect(content)}`, rules: `#{inspect(rules)}`"
+    raise ArgumentError, "[MapRewire] expected rules to be a list, map, or string."
   end
 
-  def rewire(content, _rules, _options) when not is_map(content) do
-    raise ArgumentError,
-          "[MapRewire:content<~>rules] expected content to be a map, got `#{inspect(content)}`"
-  end
 
-  def rewire(content, rules, _options) do
-    raise ArgumentError,
-          "[MapRewire:content<~>rules] bad arguments. Error reason not known. " <>
-            "Please check inspections: content: `#{inspect(content)}`, rules: `#{inspect(rules)}`"
-  end
 
   defp normalize_rules(rules, debug) when is_binary(rules) do
-    if(debug, do: Logger.info("[MapRewire]normalize_rules#rules (String): #{inspect(rules)}"))
+    log(debug, "[MapRewire]normalize_rules#rules (String): #{inspect(rules)}")
 
     rules
     |> String.split(~r/\s/)
@@ -160,4 +148,8 @@ defmodule MapRewire do
     if(debug, do: Logger.info("[MapRewire]rewire_entry: from #{old} to #{new}"))
     {new, Map.get(map, old, @no_match)}
   end
+
+  defp log(false, _), do: nil
+
+  defp log(true, message), do: Logger.info(message)
 end

--- a/lib/map_rewire.ex
+++ b/lib/map_rewire.ex
@@ -48,6 +48,11 @@ defmodule MapRewire do
 
   defmacro __using__(_) do
     quote do
+      IO.warn(
+        "use MapRewire is deprecated; import it directly instead",
+        Macro.env().stacktrace(__ENV__)
+      )
+
       import MapRewire
     end
   end

--- a/lib/map_rewire.ex
+++ b/lib/map_rewire.ex
@@ -42,7 +42,7 @@ defmodule MapRewire do
 
   @debug Application.get_env(:map_rewire, :debug?)
   @transform_to "=>"
-  @no_match "<~>NoMatch<~>" <> Base.encode16(:crypto.strong_rand_bytes(32))
+  @key_missing "<~>NoMatch<~>" <> Base.encode16(:crypto.strong_rand_bytes(16))
 
   require Logger
 

--- a/lib/map_rewire.ex
+++ b/lib/map_rewire.ex
@@ -1,85 +1,283 @@
 defmodule MapRewire do
   @moduledoc """
-  MapRewire provides functions and operators to bulk rekey maps.
+  MapRewire makes it easier to rewire maps, such as might be done when
+  translating from an external API result to an internal value or taking the
+  output of one external API and transforming it the input shape of an entirely
+  different external API.
+
+  To rewire a map, build transformation rules and call `rewire/3`, or if
+  MapRewire has been `import`ed, use the operator, `<~>`.
 
   ```
-  iex> %{"id" => "234923409", "title" => "asdf"} <~> ~w(title=>name id=>shopify_id)
-  {:ok, %{"id" => "234923409", "title" => "asdf"}, %{"shopify_id" => "234923409", "name" => "asdf"}}
+  iex> map   = %{"id" => "234923409", "title" => "asdf"}
+  iex> rules = "title=>name id=>shopify_id"
+  iex> map <~> rules
+  {%{"id" => "234923409", "title" => "asdf"}, %{"shopify_id" => "234923409", "name" => "asdf"}}
+  iex> MapRewire.rewire(map, rules) == (map <~> rules)
+  true
   ```
+
+  ## Rewire Rules
+
+  The rewire rules have three basic forms.
+
+  1.  A string containing string rename rules separated by whitespace.
+
+      ```
+      iex> map   = %{"id" => "234923409", "title" => "asdf"}
+      iex> rules = "title=>name id=>shopify_id"
+      iex> map <~> rules
+      {%{"id" => "234923409", "title" => "asdf"}, %{"shopify_id" => "234923409", "name" => "asdf"}}
+      ```
+
+      Here, `rules` normalizes to: `[{"title", "name"}, {"id", "shopify_id"}]`.
+
+  2.  A list of strings with one string rename rule in each string.
+
+      ```
+      iex> map   = %{"id" => "234923409", "title" => "asdf"}
+      iex> rules = ["title=>name", "id=>shopify_id"]
+      iex> map <~> rules
+      {%{"id" => "234923409", "title" => "asdf"}, %{"shopify_id" => "234923409", "name" => "asdf"}}
+      ```
+
+      Here, rules normalizes to: `[{"title", "name"}, {"id", "shopify_id"}]`.
+
+  3.  Any enumerable value that iterates as key/value tuples (map, keyword
+      list, or a list of 2-tuples). These may be either rename rules, or may
+      be more complex key transform rules.
+
+      ```
+      iex> map   = %{id: "234923409", title: "asdf"}
+      iex> rules = [title: :name, id: :shopify_id]
+      iex> map <~> rules
+      {%{id: "234923409", title: "asdf"}, %{shopify_id: "234923409", name: "asdf"}}
+
+      iex> map   = %{"id" => "234923409", "title" => "asdf"}
+      iex> rules = [{"title", "name"}, {"id", "shopify_id"}]
+      iex> map <~> rules
+      {%{"id" => "234923409", "title" => "asdf"}, %{"shopify_id" => "234923409", "name" => "asdf"}}
+
+      iex> map   = %{"id" => "234923409", "title" => "asdf"}
+      iex> rules = %{"title" => :name, "id" => :shopify_id}
+      iex> map <~> rules
+      {%{"id" => "234923409", "title" => "asdf"}, %{shopify_id: "234923409", name: "asdf"}}
+
+      # This is legal, but really ugly. Don't do it.
+      iex> map   = %{"id" => "234923409", "title" => "asdf"}
+      iex> rules = ["title=>name", {"id", "shopify_id"}]
+      iex> map <~> rules
+      {%{"id" => "234923409", "title" => "asdf"}, %{"shopify_id" => "234923409", "name" => "asdf"}}
+      ```
+
+  ### Rename Rules
+
+  Rename rules take the value of the old key from the source map and write it
+  to the target map as the new key, like `"title=>name"`, `%{"title" =>
+  "name"}`, and `[title: :name]` that normalize to `{old_key, new_key}`. Both
+  `old_key` and `new_key` are typically atoms or strings, but may be any valid
+  Map key value, except for the forms noted below.
+
+  ### Advanced Rules
+
+  There are two types of advanced rules (keys with options and producer
+  functions), which can only be provided when the rules are in an enumerable
+  format such as a keyword list, map, or list of tuples.
+
+  #### Keys with Options
+
+  The new key is provided as a tuple `{new_key, options}`. Supported options
+  are `:transform` (expecting a `t:transformer/0` function) and `:default`,
+  expecting any normal map value. The `:default` will work as the third
+  parameter of `Map.get/3` and be used instead of `key_missing/0`.
+
+  ```
+  iex> map   = %{"title" => "asdf"}
+  iex> rules = %{"title" => {:name, transform: &String.reverse/1}}
+  iex> map <~> rules
+  {%{"title" => "asdf"}, %{name: "fdsa"}}
+
+  # If "title" could be missing from the source map, the `transform` function
+  # should be written to handle `key_missing/0` values or have its own safe
+  # `default` value.
+  iex> map   = %{}
+  iex> rules = %{"title" => {:name, default: "unknown", transform: &String.reverse/1}}
+  iex> map <~> rules
+  {%{}, %{name: "nwonknu"}}
+  ```
+
+  #### Producer Functions
+
+  Producer functions (`t:producer/0`) take in the value and return zero or more
+  key/value tuples. It may be provided either as `producer` or `{producer,
+  options}` as shown below.
+
+  iex> dcs = fn value ->
+  ...>   unless MapRewire.key_missing?(value) do
+  ...>     [dept, class, subclass] =
+  ...>       value
+  ...>       |> String.split("-", parts: 3)
+  ...>       |> Enum.map(&String.to_integer/1)
+  ...>
+  ...>     Enum.to_list(%{"department" => dept, "class" => class, "subclass" => subclass})
+  ...>   end
+  ...> end
+  iex> map   = %{"title" => "asdf", "dcs" => "1-3-5"}
+  iex> rules = %{"title" => "name", "dcs" => dcs}
+  iex> map <~> rules
+  {%{"title" => "asdf", "dcs" => "1-3-5"}, %{"name" => "asdf", "department" => 1, "class" => 3, "subclass" => 5}}
+
+  # If "title" could be missing from the source map, the `transform` function
+  # should be written to handle `key_missing/0` values or have its own safe
+  # `default` value.
+
+  iex> dcs = fn value ->
+  ...>   [dept, class, subclass] =
+  ...>     value
+  ...>     |> String.split("-", parts: 3)
+  ...>     |> Enum.map(&String.to_integer/1)
+  ...>
+  ...>   Enum.to_list(%{"department" => dept, "class" => class, "subclass" => subclass})
+  ...> end
+  iex> map   = %{"title" => "asdf"}
+  iex> rules = %{"title" => "name", "dcs" => {dcs, default: "0-0-0"}}
+  iex> map <~> rules
+  {%{"title" => "asdf"}, %{"name" => "asdf", "department" => 0, "class" => 0, "subclass" => 0}}
   """
 
-  @typedoc """
-  The shape of MapRewire transformation rules. These rules may be specified in
-  one of several ways. Transforms specified as strings are in the form
-  `left=>right` (note that there are no spaces around the arrow).
-
-  1.  As a string with multiple transforms separated by whitespace:
-
-      ```
-      "title=>name id=>shopify_id"
-      ```
-
-  2.  As a list of strings with one transform per string:
-
-      ```
-      ["title=>name", "id=>shopify_id"]
-      ```
-
-  3.  As any enumerable that iterates as tuples:
-
-      ```
-      [title: :name, id: :shopify_id]
-      [{"title", "name"}, {"id", "shopify_id"}]
-      %{"title" => :name, "id" => :shopify_id}
-      ```
-  """
-  @type transform_rules ::
-          String.t()
-          | list(String.t())
-          | keyword
-          | map
-          | list({String.t() | atom, String.t() | atom})
-
-  @debug Application.get_env(:map_rewire, :debug?)
   @transform_to "=>"
   @key_missing "<~>NoMatch<~>" <> Base.encode16(:crypto.strong_rand_bytes(16))
 
   require Logger
 
-  defmacro __using__(_) do
-    quote do
-      IO.warn(
-        "use MapRewire is deprecated; import it directly instead",
-        Macro.env().stacktrace(__ENV__)
-      )
+  @typedoc """
+  A function that, given a map `value`, produces zero or more key/value tuples.
 
-      import MapRewire
+  The `value` provided may be `key_missing/0`, so `key_missing?/1` should be
+  used to compare before blindly operating on `value`.
+
+  If no keys are to be produced (possibly because `value` is `key_missing/0`),
+  either `nil` or an empty list (`[]`) should be returned.
+
+  ```
+  fn value ->
+    unless MapRewire.key_missing?(value) do
+      [dept, class, subclass] =
+        value
+        |> String.split("-", parts: 3)
+        |> Enum.map(&String.to_integer/1)
+
+      Enum.to_list(%{"department" => dept, "class" => class, "subclass" => subclass})
     end
   end
+  ```
+  """
+  @type producer ::
+          (Map.value() -> nil | {Map.key(), Map.value()} | list({Map.key(), Map.value()}))
+
+  @typedoc """
+  A function that, given a map `value`, transforms it before insertion into the
+  target map.
+
+  The `value` may be `key_missing/0`, so `key_missing?/1` should be used to
+  compare before blindly operating on `value`.
+
+  If the key should be omitted when `rewire/3` is called, `key_missing/0`
+  should be returned.
+
+  ```
+  fn value ->
+    cond do
+      MapRewire.key_missing?(value) ->
+        value
+
+      is_binary(value) ->
+        String.reverse(value)
+
+      true ->
+        String.reverse(to_string(value))
+    end
+  end
+  ```
+  """
+  @type transformer :: (Map.value() -> Map.value())
+
+  @typedoc "Advanced rewire rule options"
+  @type rewire_rule_options :: [transform: transformer, default: Map.value()]
+
+  @typedoc "Rewire rule target values."
+  @type rewire_rule_target ::
+          Map.key()
+          | producer
+          | {producer, [default: Map.value()]}
+          | {Map.key(), rewire_rule_options}
+
+  @typedoc "A normalized rewire rule."
+  @type rewire_rule :: {old :: Map.key(), rewire_rule_target}
+
+  @typedoc """
+  The shape of MapRewire transformation rules.
+
+  Note that although keyword lists and maps may be used, the values must be
+  `t:rewire_rule_target/0` values.
+  """
+  @type rewire_rules ::
+          String.t()
+          | list(String.t())
+          | keyword
+          | map
+          | list(rewire_rule)
+
+  defmacro __using__(options) do
+    if Keyword.get(options, :warn, true) do
+      IO.warn(
+        "use MapRewire is deprecated; import it directly instead",
+        Macro.Env.stacktrace(__ENV__)
+      )
+    end
+
+    quote(do: import(MapRewire))
+  end
 
   @doc """
-  Remaps the map `content` and replaces the key if it matches with an item in
-  `list`. This makes `MapRewire.rewire/2` act as an operator.
+  The operator form of `rewire/3`, which remaps the map `content` and replaces
+  the key if it matches with an item in `rewire_rules`.
   """
-  def data <~> transforms do
-    rewire(data, transforms, debug: false)
+  def content <~> rewire_rules do
+    rewire(content, rewire_rules, debug: false)
   end
 
   @doc """
   Remaps the map `content` and replaces the key if it matches with an item in
-  `list`.
+  `rules`.
 
-  ```
-  iex> MapRewire.rewrite(%{"id"=>"234923409", "title"=>"asdf"}, ~w(title=>name id=>shopify_id))
-  {:ok, %{"id" => "234923409", "title" => "asdf"}, %{"shopify_id" => "234923409", "name" => "asdf"}}
-  ```
+  Accepts two options:
+
+  -   `:debug` controls the logging of the steps taken to transform `content`
+      using `rules`. The default is `Application.get_env(:map_rewire,
+      :debug?)`.
+
+  -   `:compact` which controls the removal of values from the result map for
+      keys missing in the `content` map. The default is `true`.
+
+      ```
+      iex> map   = %{"title" => "asdf"}
+      iex> rules = %{"title" => :name, "missing" => :missing}
+      iex> rewire(map, rules, compact: true) # the default
+      {%{"title" => "asdf"}, %{name: "asdf"}}
+
+      iex> map   = %{"title" => "asdf"}
+      iex> rules = %{"title" => :name, "missing" => :missing}
+      iex> rewire(map, rules, compact: false)
+      {%{"title" => "asdf"}, %{name: "asdf", missing: nil}}
+      ```
   """
-  @spec rewire(map, transform_rules, keyword) :: {:ok, old :: map, new :: map}
+  @spec rewire(map, rewire_rules, keyword) :: {old :: map, new :: map}
   def rewire(content, rules, options \\ [])
 
   def rewire(content, rules, options)
       when is_map(content) and (is_list(rules) or is_binary(rules) or is_map(rules)) do
-    debug = !!Keyword.get(options, :debug, @debug)
+    debug = Keyword.get(options, :debug, Application.get_env(:map_rewire, :debug?)) === true
 
     log(debug, "[MapRewire]rewire#content: #{inspect(content)}")
     log(debug, "[MapRewire]rewire#rules: #{inspect(rules)}")
@@ -88,19 +286,44 @@ defmodule MapRewire do
     new =
       rules
       |> normalize_rules(debug)
-      |> Enum.map(&rewire_entry(&1, content, debug))
-      |> Enum.reject(&match?({_, @no_match}, &1))
+      |> Enum.flat_map(&rewire_entry(&1, content, debug))
+      |> compact(Keyword.get(options, :compact, true))
+      |> Enum.reject(&match?({_, @key_missing}, &1))
       |> Enum.into(%{})
 
     {content, new}
   end
 
   def rewire(content, rules, _options) when is_map(content) do
-    raise ArgumentError, "[MapRewire] expected rules to be a list, map, or string."
+    raise ArgumentError,
+          "[MapRewire] expected rules to be a list, map, or string, got #{inspect(rules)}."
   end
 
+  @doc """
+  The value used in rewire operations if an old key does not exist in the
+  source map.
 
+  Normally, when the rewired map is produced, keys containing this value will
+  be removed from the rewired map, but providing the option `compact: false` to
+  `rewire/3` will replace this value with `nil`.
 
+  The value in `key_missing/0` may be provided to `t:producer/0` and
+  `t:transformer/0` functions, so `key_missing?/1` should be used to determine
+  the correct response if this value is received (see the documentation for
+  these function types).
+
+  Note that the value of `key_missing/0` is a 45-byte binary value with a 13-byte
+  fixed head (`"<~>NoMatch<~>"`) and a random value that changes whenever
+  MapRewire is recompiled.
+  """
+  @spec key_missing :: binary
+  def key_missing, do: @key_missing
+
+  @doc "Returns true if `value` is the same as `key_missing/0`."
+  @spec key_missing?(Map.value()) :: boolean
+  def key_missing?(value), do: value === key_missing()
+
+  @spec normalize_rules(String.t(), boolean) :: list(rewire_rule)
   defp normalize_rules(rules, debug) when is_binary(rules) do
     log(debug, "[MapRewire]normalize_rules#rules (String): #{inspect(rules)}")
 
@@ -109,46 +332,88 @@ defmodule MapRewire do
     |> Enum.map(&normalize_rule(&1, debug))
   end
 
+  @spec normalize_rules(list(String.t() | rewire_rule), boolean) :: list(rewire_rule)
   defp normalize_rules(rules, debug) when is_list(rules) do
-    if(debug, do: Logger.info("[MapRewire]normalize_rules#rules (List): #{inspect(rules)}"))
+    log(debug, "[MapRewire]normalize_rules#rules (List): #{inspect(rules)}")
     Enum.map(rules, &normalize_rule(&1, debug))
   end
 
+  @spec normalize_rules(map, boolean) :: list(rewire_rule)
   defp normalize_rules(rules, debug) when is_map(rules) do
-    if(debug, do: Logger.info("[MapRewire]normalize_rules#rules (Map): #{inspect(rules)}"))
+    log(debug, "[MapRewire]normalize_rules#rules (Map): #{inspect(rules)}")
     Enum.to_list(rules)
   end
 
+  @spec normalize_rule(String.t() | rewire_rule | list, boolean) :: rewire_rule | no_return
   defp normalize_rule({_old, _new} = rule, debug) do
-    if(debug, do: Logger.info("[MapRewire]normalize_rule#rule (Tuple): #{inspect(rule)}"))
+    log(debug, "[MapRewire]normalize_rule#rule (Tuple): #{inspect(rule)}")
     rule
   end
 
   defp normalize_rule(rule, debug) when is_binary(rule) do
-    if(debug, do: Logger.info("[MapRewire]normalize_rule#rule (String): #{inspect(rule)}"))
+    log(debug, "[MapRewire]normalize_rule#rule (String): #{inspect(rule)}")
     List.to_tuple(String.split(rule, @transform_to))
   end
 
   defp normalize_rule(rule, _) when is_list(rule) and length(rule) != 2 do
-    raise ArgumentError,
-          "[MapRewire:content<~>rules] bad argument: invalid rule format #{inspect(rule)}"
+    raise ArgumentError, "[MapRewire] bad argument: invalid rule format #{inspect(rule)}"
   end
 
   defp normalize_rule(rule, debug) when is_list(rule) do
-    if(debug, do: Logger.info("[MapRewire]normalize_rule#rule (List-2): #{inspect(rule)}"))
+    log(debug, "[MapRewire]normalize_rule#rule (List-2): #{inspect(rule)}")
     List.to_tuple(rule)
   end
 
   defp normalize_rule(rule, _) do
-    raise ArgumentError,
-          "[MapRewire:content<~>rules] bad argument: invalid rule format #{inspect(rule)}"
+    raise ArgumentError, "[MapRewire] bad argument: invalid rule format #{inspect(rule)}"
+  end
+
+  @spec rewire_entry(rewire_rule, map, boolean) :: list({Map.key(), Map.value()})
+  defp rewire_entry({old, {producer, options}}, map, debug) when is_function(producer) do
+    log(
+      debug,
+      "[MapRewire]rewire_entry: from #{inspect(old)} with a producer function and options #{
+        inspect(options)
+      }"
+    )
+
+    List.wrap(producer.(Map.get(map, old, Keyword.get(options, :default, @key_missing))))
+  end
+
+  defp rewire_entry({old, {new, options}}, map, debug) do
+    log(
+      debug,
+      "[MapRewire]rewire_entry: from #{inspect(old)} to #{inspect(new)} with options #{
+        inspect(options)
+      }"
+    )
+
+    value = Map.get(map, old, Keyword.get(options, :default, @key_missing))
+    value = if(fun = Keyword.get(options, :transform), do: fun.(value), else: value)
+    [{new, value}]
+  end
+
+  defp rewire_entry({old, producer}, map, debug) when is_function(producer) do
+    log(debug, "[MapRewire]rewire_entry: from #{inspect(old)} with a producer function")
+    List.wrap(producer.(Map.get(map, old, @key_missing)))
   end
 
   defp rewire_entry({old, new}, map, debug) do
-    if(debug, do: Logger.info("[MapRewire]rewire_entry: from #{old} to #{new}"))
-    {new, Map.get(map, old, @no_match)}
+    log(debug, "[MapRewire]rewire_entry: from #{inspect(old)} to #{inspect(new)}")
+    [{new, Map.get(map, old, @key_missing)}]
   end
 
+  @spec compact(list({Map.key(), Map.value()}), boolean) :: list({Map.key(), Map.value()})
+  defp compact(rewired, true), do: Enum.reject(rewired, &match?({_, @key_missing}, &1))
+
+  defp compact(rewired, false) do
+    Enum.map(rewired, fn
+      {k, @key_missing} -> {k, nil}
+      pair -> pair
+    end)
+  end
+
+  @spec log(boolean, String.t() | function) :: any()
   defp log(false, _), do: nil
 
   defp log(true, message), do: Logger.info(message)

--- a/test/map_rewire_test.exs
+++ b/test/map_rewire_test.exs
@@ -1,6 +1,8 @@
 defmodule MapRewireTest do
   use ExUnit.Case, async: true
-  use MapRewire
+  use MapRewire, warn: false
+
+  doctest MapRewire, import: true
 
   setup _context do
     {:ok, SampleData.sample()}

--- a/test/speed_runner.ex
+++ b/test/speed_runner.ex
@@ -1,4 +1,6 @@
 defmodule SpeedRunner do
+  @moduledoc false
+
   import ExProf.Macro
 
   @data SampleData.sample()

--- a/test/support/sample_data.ex
+++ b/test/support/sample_data.ex
@@ -1,4 +1,6 @@
 defmodule SampleData do
+  @moduledoc false
+
   def sample do
     [
       content: [


### PR DESCRIPTION
In addition to the (modified) forms I talked about in #1, I have added a
producer function form that allows you to take a single value and decode it
into multiple keys. I have added lots of documentation on this, and all of the
new functionality is supported through doctests.

I have provided what I believe to be the correct typespecs for everything, and
have documented quite a few more.

Also:

-   Made the check for `:map_rewire, :debug?` no longer compile-time
    configured. It needs to be read on a per-run basis. The reasoning for this
    is that I can now turn on logging of the transform debugging at runtime
    even in live code just by using `Application.put_env/3`.

-   Deprecate `use MapRewire`, per best practices for `use`:
    https://hexdocs.pm/elixir/Kernel.html#use/2-best-practices

-   Shortened the unique string for `@key_missing`.

-   Logging housekeeping

    -   I’ve added a log/2 function that simplifies the logging lines so we
        don’t have to wrap every call to `Logger.info/1` in `if/1`.

    -   I have removed most of the `inspect/1` calls, as in production
        environments, `content` maps may contain PII that should not show up in
        logfiles.

    -   I have removed two of the heads for `rewire/3` because the
        `ArgumentError` messages are less useful than the default case where
        the BEAM complains about a missing HEAD. These should only show up in
        development in any case. Also, the `content` map was being inspected in
        both of them, which for PII reasons is not recommended.

----

I’m out of town for the weekend, but I’ll be happy to talk through any of these
when I’m back.